### PR TITLE
Move tooltip to the right side next to the edge of the chart

### DIFF
--- a/vega/viz.js
+++ b/vega/viz.js
@@ -31,7 +31,7 @@ function change(){
           "streams": [
             {
               "type": "mousemove",
-              "expr": "eventX()",
+              "expr": "eventX() > width - 155 ? eventX() - 155 : eventX()",
               "scale": {"name": "x","invert": true}
             }
           ]


### PR DESCRIPTION
As an alternative, you could simply use https://github.com/vega/vega-tooltip